### PR TITLE
Sort by RoundType in success streak.

### DIFF
--- a/misc/python/statistics/longest_success_streak.py
+++ b/misc/python/statistics/longest_success_streak.py
@@ -39,13 +39,13 @@ from
     Results r
 inner join Competitions c on
 	r.competitionId = c.id
-inner join Events e on
-	r.eventId = e.id
+inner join RoundTypes rt on
+	r.roundTypeId = rt.id
 where
     eventId = %(event_id)s
 order by
 	start_date,
-	e.`rank`"""
+	rt.`rank`"""
 
 
 def longest_streaks():


### PR DESCRIPTION
Currently the longest_success_streak query does not sort rounds, which leads to nondeterminism when a streak begins / ends during a multi-round competition.

In addition, stop joining with Events because this table is not used in the query.

Fixes #89.