### PR TITLE
fix off-by-one issue with paging

### DIFF
--- a/server/src/main/java/org/worldcubeassociation/statistics/repository/jdbc/impl/SumOfRanksRepositoryImpl.java
+++ b/server/src/main/java/org/worldcubeassociation/statistics/repository/jdbc/impl/SumOfRanksRepositoryImpl.java
@@ -112,6 +112,6 @@ public class SumOfRanksRepositoryImpl implements SumOfRanksRepository {
                         .addValue("PAGE_SIZE", pageSize)
                         .addValue("WCA_ID", wcaId), Integer.class);
 
-        return Optional.ofNullable(list.size() != 1 ? null : list.get(0) - 1);
+        return Optional.ofNullable(list.size() != 1 ? null : list.get(0));
     }
 }

--- a/server/src/main/java/org/worldcubeassociation/statistics/repository/jdbc/impl/SumOfRanksRepositoryImpl.java
+++ b/server/src/main/java/org/worldcubeassociation/statistics/repository/jdbc/impl/SumOfRanksRepositoryImpl.java
@@ -112,6 +112,6 @@ public class SumOfRanksRepositoryImpl implements SumOfRanksRepository {
                         .addValue("PAGE_SIZE", pageSize)
                         .addValue("WCA_ID", wcaId), Integer.class);
 
-        return Optional.ofNullable(list.size() != 1 ? null : list.get(0));
+        return Optional.ofNullable(list.size() != 1 ? null : list.get(0) - 1);
     }
 }

--- a/server/src/main/resources/db/query/sumofranks/getWcaIdPage.sql
+++ b/server/src/main/resources/db/query/sumofranks/getWcaIdPage.sql
@@ -1,5 +1,5 @@
 select
-    floor(region_rank / :PAGE_SIZE)
+    floor((region_rank - 1) / :PAGE_SIZE)
 from
     sum_of_ranks sor
 where


### PR DESCRIPTION
This pull request only changes one line.

It also addresses issue https://github.com/thewca/statistics/issues/87 which was opened a year ago.

The issue arises if you try to get a user who is an exact multiple of 20 (note that 20 is the page size). For example, the 100th user should get page 81-100, but instead gets 101-120

For example, look at the [sum of ranks page](https://statistics.worldcubeassociation.org/sum-of-ranks) and enter 2011SBAH01. He should be the 100th user, but instead it shows #101-120