### PR TITLE
Fix deploy action

### DIFF
--- a/.github/workflows/backdeploy.yaml
+++ b/.github/workflows/backdeploy.yaml
@@ -37,15 +37,6 @@ jobs:
           sed -i "s|version: 1.0.0|version: ${GIT_HASH}|g" server/src/main/resources/application.yaml
       - name: Build jar
         run: ./server/gradlew build -p server -x test
-      - name: Restore application.yaml
-        run: git checkout server/src/main/resources/application.yaml
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
       - name: Build and push to ECR
         run: |
           cd server

--- a/.github/workflows/backtest.yaml
+++ b/.github/workflows/backtest.yaml
@@ -1,12 +1,6 @@
 name: Backend
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "server/**"
-      - ".github/workflows/backtest.yaml"
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Version was not being persisted in swagger documentation, also we were using old support to dockerhub (but we changed it with ECR after dockerhub played the prank to become paid).