### PR TITLE
Add caching for statistics

### DIFF
--- a/server/src/main/java/org/worldcubeassociation/statistics/service/impl/StatisticsServiceImpl.java
+++ b/server/src/main/java/org/worldcubeassociation/statistics/service/impl/StatisticsServiceImpl.java
@@ -198,8 +198,8 @@ public class StatisticsServiceImpl implements StatisticsService {
 
         if (StringUtils.isBlank(term)) {
             var cache = CACHE.get(MAIN_LIST_CACHE);
-            if (cache != null && cache.getFirst().plusDays(1).isBefore(LocalDateTime.now())) {
-                return objectMapper.convertValue(cache.getSecond(), StatisticsListDTO.class);
+            if (cache != null && cache.getFirst().plusDays(1).isAfter(LocalDateTime.now())) {
+                return (StatisticsListDTO) cache.getSecond();
             }
         }
 
@@ -232,8 +232,8 @@ public class StatisticsServiceImpl implements StatisticsService {
     @Override
     public StatisticsResponseDTO getStatistic(String path) {
         var cache = CACHE.get(path);
-        if (cache != null && cache.getFirst().plusDays(1).isBefore(LocalDateTime.now())) {
-            return objectMapper.convertValue(cache.getSecond(), StatisticsResponseDTO.class);
+        if (cache != null && cache.getFirst().plusDays(1).isAfter(LocalDateTime.now())) {
+            return (StatisticsResponseDTO) cache.getSecond();
         }
 
         Statistics statistics = statisticsRepository.findById(path)
@@ -263,10 +263,9 @@ public class StatisticsServiceImpl implements StatisticsService {
         statisticsResponseDTO.setPath(path);
         statisticsResponseDTO.setGroupName(statisticsDTO.getGroupName());
 
-        statisticsResponseDTO.getStatistics().forEach(stat -> {
-            Optional.ofNullable(stat.getSqlQueryCustom()).ifPresent(q -> stat.setSqlQueryCustom(
-                URLEncoder.encode(q, StandardCharsets.UTF_8)));
-        });
+        statisticsResponseDTO.getStatistics().forEach(
+            stat -> Optional.ofNullable(stat.getSqlQueryCustom()).ifPresent(
+                q -> stat.setSqlQueryCustom(URLEncoder.encode(q, StandardCharsets.UTF_8))));
 
         saveStatistics(statisticsResponseDTO);
 

--- a/server/src/main/java/org/worldcubeassociation/statistics/service/impl/StatisticsServiceImpl.java
+++ b/server/src/main/java/org/worldcubeassociation/statistics/service/impl/StatisticsServiceImpl.java
@@ -63,6 +63,7 @@ public class StatisticsServiceImpl implements StatisticsService {
     // We should move to redis to cache the statistics instead
     private static final Map<String, Pair<LocalDateTime, Object>> CACHE = new HashMap<>();
     private static final String MAIN_LIST_CACHE = "MAIN_LIST_CACHE";
+    private static final int CACHING_TIME = 6;
 
     @Override
     public StatisticsResponseDTO sqlToStatistics(StatisticsRequestDTO statisticsRequestDTO) {
@@ -198,7 +199,8 @@ public class StatisticsServiceImpl implements StatisticsService {
 
         if (StringUtils.isBlank(term)) {
             var cache = CACHE.get(MAIN_LIST_CACHE);
-            if (cache != null && cache.getFirst().plusDays(1).isAfter(LocalDateTime.now())) {
+            if (cache != null && cache.getFirst().plusHours(CACHING_TIME)
+                .isAfter(LocalDateTime.now())) {
                 return (StatisticsListDTO) cache.getSecond();
             }
         }
@@ -232,7 +234,8 @@ public class StatisticsServiceImpl implements StatisticsService {
     @Override
     public StatisticsResponseDTO getStatistic(String path) {
         var cache = CACHE.get(path);
-        if (cache != null && cache.getFirst().plusDays(1).isAfter(LocalDateTime.now())) {
+        if (cache != null && cache.getFirst().plusHours(CACHING_TIME)
+            .isAfter(LocalDateTime.now())) {
             return (StatisticsResponseDTO) cache.getSecond();
         }
 


### PR DESCRIPTION
This is a quick fix for the issue we are having in the statistics website. It is taking too long to load. Every request was running in the database. Now, we are caching the main list and also the statistics detail. We just won't cache the terms searched for now. Caching time is 6 hours because there can be a scenario where we cache in the middle of an updated. Results would be incorrect for the caching duration, so we make it kind of short.