### PR TITLE
Further fix for oldest standing records

### DIFF
--- a/server/src/main/resources/statistics-request-list/oldest-standing-records.yml
+++ b/server/src/main/resources/statistics-request-list/oldest-standing-records.yml
@@ -17,8 +17,6 @@ queries:
             *
           from
             results r
-            inner join events e on r.event_id = e.id
-            and e.`rank` < 900            
           where
             r.best > 0
             and regional_single_record = 'WR'
@@ -39,11 +37,9 @@ queries:
             *
           from
             results r
-            inner join events e on r.event_id = e.id
-            and e.`rank` < 900
           where
             r.average > 0
-            and regional_single_record = 'WR'
+            and regional_average_record = 'WR'
             and not exists (
               select
                 1
@@ -53,7 +49,7 @@ queries:
                 r2.event_id = r.event_id
                 and r2.average < r.average
                 and r2.average > 0
-                and r2.regional_single_record = 'WR'
+                and r2.regional_average_record = 'WR'
             )
         ),
         combined_wr as (
@@ -74,7 +70,7 @@ queries:
             c.start_date,
             event_id,
             'Average' record_type,
-            best record,
+            average record,
             person_id,
             r.person_name,
             c.id competition_id,
@@ -92,6 +88,9 @@ queries:
         wca_statistics_competition_link_format (competition_id, competition)
       from
         combined_wr cw
+        inner join events e on cw.event_id = e.id
+      where
+        e.`rank` < 900
       order by
         1 desc,
         event_id,

--- a/server/src/main/resources/statistics-request-list/oldest-standing-records.yml
+++ b/server/src/main/resources/statistics-request-list/oldest-standing-records.yml
@@ -12,7 +12,51 @@ queries:
       - Competition
     sqlQuery: |-
       with
-        ordered_wrs as (
+        current_single as (
+          select
+            *
+          from
+            results r
+            inner join events e on r.event_id = e.id
+            and e.`rank` < 900            
+          where
+            r.best > 0
+            and regional_single_record = 'WR'
+            and not exists (
+              select
+                1
+              from
+                results r2
+              where
+                r2.event_id = r.event_id
+                and r2.best < r.best
+                and r2.best > 0
+                and r2.regional_single_record = 'WR'
+            )
+        ),
+        current_average as (
+          select
+            *
+          from
+            results r
+            inner join events e on r.event_id = e.id
+            and e.`rank` < 900
+          where
+            r.average > 0
+            and regional_single_record = 'WR'
+            and not exists (
+              select
+                1
+              from
+                results r2
+              where
+                r2.event_id = r.event_id
+                and r2.average < r.average
+                and r2.average > 0
+                and r2.regional_single_record = 'WR'
+            )
+        ),
+        combined_wr as (
           select
             c.start_date,
             event_id,
@@ -21,18 +65,10 @@ queries:
             person_id,
             r.person_name,
             c.id competition_id,
-            c.name competition,
-            row_number() over (
-              partition by
-                event_id
-              order by
-                c.start_date desc
-            ) rn
+            c.name competition
           from
-            results r
+            current_single r
             inner join competitions c on r.competition_id = c.id
-          where
-            regional_single_record = 'WR'
           union all
           select
             c.start_date,
@@ -42,26 +78,10 @@ queries:
             person_id,
             r.person_name,
             c.id competition_id,
-            c.name competition,
-            row_number() over (
-              partition by
-                event_id
-              order by
-                c.start_date desc
-            ) rn
+            c.name competition
           from
-            results r
+            current_average r
             inner join competitions c on r.competition_id = c.id
-          where
-            regional_average_record = 'WR'
-        ),
-        current_wrs as (
-          select
-            *
-          from
-            ordered_wrs
-          where
-            rn = 1
         )
       select
         datediff (current_date, start_date) days,
@@ -71,13 +91,11 @@ queries:
         wca_statistics_person_link_format (person_id, person_name),
         wca_statistics_competition_link_format (competition_id, competition)
       from
-        current_wrs cw
-        inner join events e on e.id = cw.event_id
-      where
-        e.rank < 900
+        combined_wr cw
       order by
         1 desc,
-        e.rank
+        event_id,
+        record_type
       limit
         20
   - showPositions: true

--- a/server/src/main/resources/statistics-request-list/oldest-standing-records.yml
+++ b/server/src/main/resources/statistics-request-list/oldest-standing-records.yml
@@ -224,81 +224,6 @@ queries:
       - Competition
     sqlQuery: |-
       with
-        ordered_records as (
-          select
-            c.start_date,
-            event_id,
-            'Single' record_type,
-            best record,
-            person_id,
-            r.person_name,
-            c.id competition_id,
-            c.name competition,
-            r.country_id region,
-            row_number() over (
-              partition by
-                event_id,
-                r.country_id
-              order by
-                c.start_date desc
-            ) rn
-          from
-            results r
-            inner join competitions c on r.competition_id = c.id
-          where
-            regional_single_record = 'NR'
-          union all
-          select
-            c.start_date,
-            event_id,
-            'Average' record_type,
-            best record,
-            person_id,
-            r.person_name,
-            c.id competition_id,
-            c.name competition,
-            r.country_id region,
-            row_number() over (
-              partition by
-                event_id,
-                r.country_id
-              order by
-                c.start_date desc
-            ) rn
-          from
-            results r
-            inner join competitions c on r.competition_id = c.id
-          where
-            regional_average_record = 'NR'
-        ),
-        current_records as (
-          select
-            *
-          from
-            ordered_records
-          where
-            rn = 1
-        )
-      select
-        datediff (current_date, start_date) days,
-        e.name,
-        wca_statistics_time_format (record, event_id, record_type) record,
-        record_type,
-        region,
-        wca_statistics_person_link_format (person_id, person_name),
-        wca_statistics_competition_link_format (competition_id, competition)
-      from
-        current_records c
-        inner join events e on e.id = c.event_id
-      where
-        e.rank < 900
-      order by
-        1 desc,
-        e.rank
-      limit
-        20
-    sqlQueryCustom: |-
-      with
         current_single as (
           select
             r.*,
@@ -390,6 +315,78 @@ queries:
         1 desc,
         event_id,
         record_type
+      limit
+        20
+    sqlQueryCustom: |-
+      with
+        ordered_results as (
+          select
+            c.start_date,
+            event_id,
+            'Single' record_type,
+            best record,
+            person_id,
+            r.person_name,
+            c.id competition_id,
+            c.name competition,
+            row_number() over (
+              partition by
+                event_id
+              order by
+                best
+            ) rn
+          from
+            results r
+            inner join competitions c on r.competition_id = c.id
+          where
+            best > 0
+            and person_id = ':WCA_ID'
+          union all
+          select
+            c.start_date,
+            event_id,
+            'Average' record_type,
+            best record,
+            person_id,
+            r.person_name,
+            c.id competition_id,
+            c.name competition,
+            row_number() over (
+              partition by
+                event_id
+              order by
+                average
+            ) rn
+          from
+            results r
+            inner join competitions c on r.competition_id = c.id
+          where
+            average > 0
+            and person_id = ':WCA_ID'
+        ),
+        current_records as (
+          select
+            *
+          from
+            ordered_results
+          where
+            rn = 1
+        )
+      select
+        datediff (current_date, start_date) days,
+        e.name,
+        wca_statistics_time_format (record, event_id, record_type) record,
+        record_type,
+        wca_statistics_person_link_format (person_id, person_name),
+        wca_statistics_competition_link_format (competition_id, competition)
+      from
+        current_records cr
+        inner join events e on e.id = cr.event_id
+      where
+        e.rank < 900
+      order by
+        1 desc,
+        e.rank
       limit
         20
 explanation: The first day of the competition is assumed here and thus the ages might be some days off.

--- a/server/src/main/resources/statistics-request-list/oldest-standing-records.yml
+++ b/server/src/main/resources/statistics-request-list/oldest-standing-records.yml
@@ -52,7 +52,7 @@ queries:
                 and r2.regional_average_record = 'WR'
             )
         ),
-        combined_wr as (
+        combined_r as (
           select
             c.start_date,
             event_id,
@@ -87,8 +87,8 @@ queries:
         wca_statistics_person_link_format (person_id, person_name),
         wca_statistics_competition_link_format (competition_id, competition)
       from
-        combined_wr cw
-        inner join events e on cw.event_id = e.id
+        combined_r c
+        inner join events e on c.event_id = e.id
       where
         e.`rank` < 900
       order by
@@ -111,66 +111,85 @@ queries:
       - Competition
     sqlQuery: |-
       with
-        ordered_records as (
+        current_single as (
+          select
+            r.*,
+            c3.name region
+          from
+            results r
+            inner join countries c on r.country_id = c.id
+            inner join continents c3 on c.continent_id = c3.id
+          where
+            r.best > 0
+            and regional_single_record is not null
+            -- was a CR first
+            and regional_single_record not in ('NR', 'WR')
+            and not exists (
+              select
+                1
+              from
+                results r2
+                inner join countries c2 on r2.country_id = c2.id
+              where
+                r2.event_id = r.event_id
+                and r2.best < r.best
+                and r2.best > 0
+                and c.continent_id = c2.continent_id
+            )
+        ),
+        current_average as (
+          select
+            r.*,
+            c3.name region
+          from
+            results r
+            inner join countries c on r.country_id = c.id
+            inner join continents c3 on c.continent_id = c3.id
+          where
+            r.average > 0
+            and regional_average_record is not null
+            and regional_average_record not in ('NR', 'WR')
+            and not exists (
+              select
+                1
+              from
+                results r2
+                inner join countries c2 on r2.country_id = c2.id
+              where
+                r2.event_id = r.event_id
+                and r2.average < r.average
+                and r2.average > 0
+                and c.continent_id = c2.continent_id
+            )
+        ),
+        combined_r as (
           select
             c.start_date,
             event_id,
             'Single' record_type,
+            region,
             best record,
             person_id,
             r.person_name,
             c.id competition_id,
-            c.name competition,
-            ctn.name region,
-            row_number() over (
-              partition by
-                event_id,
-                continent_id
-              order by
-                c.start_date desc
-            ) rn
+            c.name competition
           from
-            results r
+            current_single r
             inner join competitions c on r.competition_id = c.id
-            inner join countries ct on ct.id = r.country_id
-            inner join continents ctn on ctn.id = ct.continent_id
-          where
-            regional_single_record is not null
-            and regional_single_record not in ('WR', 'NR')
           union all
           select
             c.start_date,
             event_id,
             'Average' record_type,
-            best record,
+            region,
+            average record,
             person_id,
             r.person_name,
             c.id competition_id,
-            c.name competition,
-            ctn.name region,
-            row_number() over (
-              partition by
-                event_id,
-                continent_id
-              order by
-                c.start_date desc
-            ) rn
+            c.name competition
           from
-            results r
+            current_average r
             inner join competitions c on r.competition_id = c.id
-            inner join countries ct on ct.id = r.country_id
-            inner join continents ctn on ctn.id = ct.continent_id
-          where
-            regional_average_record is not null
-            and regional_average_record not in ('WR', 'NR')
-        ),
-        current_records as (
-          select
-            *
-          from
-            ordered_records
-          where
-            rn = 1
         )
       select
         datediff (current_date, start_date) days,
@@ -181,13 +200,14 @@ queries:
         wca_statistics_person_link_format (person_id, person_name),
         wca_statistics_competition_link_format (competition_id, competition)
       from
-        current_records cw
-        inner join events e on e.id = cw.event_id
+        combined_r c
+        inner join events e on c.event_id = e.id
       where
-        e.rank < 900
+        e.`rank` < 900
       order by
         1 desc,
-        e.rank
+        event_id,
+        record_type
       limit
         20
   - showPositions: true
@@ -268,8 +288,8 @@ queries:
         wca_statistics_person_link_format (person_id, person_name),
         wca_statistics_competition_link_format (competition_id, competition)
       from
-        current_records cw
-        inner join events e on e.id = cw.event_id
+        current_records c
+        inner join events e on e.id = c.event_id
       where
         e.rank < 900
       order by
@@ -279,74 +299,97 @@ queries:
         20
     sqlQueryCustom: |-
       with
-        ordered_results as (
+        current_single as (
+          select
+            r.*,
+            c.name region
+          from
+            results r
+            inner join countries c on r.country_id = c.id
+          where
+            r.best > 0
+            -- was an NR first
+            and regional_single_record = 'NR'
+            and not exists (
+              select
+                1
+              from
+                results r2
+              where
+                r2.event_id = r.event_id
+                and r2.best < r.best
+                and r2.best > 0
+                and r2.country_id = r.country_id
+            )
+        ),
+        current_average as (
+          select
+            r.*,
+            c.name region
+          from
+            results r
+            inner join countries c on r.country_id = c.id
+          where
+            r.average > 0
+            and regional_average_record = 'NR'
+            and not exists (
+              select
+                1
+              from
+                results r2
+              where
+                r2.event_id = r.event_id
+                and r2.average < r.average
+                and r2.average > 0
+                and r2.country_id = r.country_id
+            )
+        ),
+        combined_r as (
           select
             c.start_date,
             event_id,
             'Single' record_type,
+            region,
             best record,
             person_id,
             r.person_name,
             c.id competition_id,
-            c.name competition,
-            row_number() over (
-              partition by
-                event_id
-              order by
-                best
-            ) rn
+            c.name competition
           from
-            results r
+            current_single r
             inner join competitions c on r.competition_id = c.id
-          where
-            best > 0
-            and person_id = ':WCA_ID'
           union all
           select
             c.start_date,
             event_id,
             'Average' record_type,
-            best record,
+            region,
+            average record,
             person_id,
             r.person_name,
             c.id competition_id,
-            c.name competition,
-            row_number() over (
-              partition by
-                event_id
-              order by
-                average
-            ) rn
+            c.name competition
           from
-            results r
+            current_average r
             inner join competitions c on r.competition_id = c.id
-          where
-            average > 0
-            and person_id = ':WCA_ID'
-        ),
-        current_records as (
-          select
-            *
-          from
-            ordered_results
-          where
-            rn = 1
         )
       select
         datediff (current_date, start_date) days,
         e.name,
         wca_statistics_time_format (record, event_id, record_type) record,
         record_type,
+        region,
         wca_statistics_person_link_format (person_id, person_name),
         wca_statistics_competition_link_format (competition_id, competition)
       from
-        current_records cr
-        inner join events e on e.id = cr.event_id
+        combined_r c
+        inner join events e on c.event_id = e.id
       where
-        e.rank < 900
+        e.`rank` < 900
       order by
         1 desc,
-        e.rank
+        event_id,
+        record_type
       limit
         20
 explanation: The first day of the competition is assumed here and thus the ages might be some days off.


### PR DESCRIPTION
This pull request significantly refactors the SQL queries in `oldest-standing-records.yml` to improve accuracy and clarity in determining the oldest standing world, continental, and national records. The changes focus on ensuring only the current records are selected (not all historical records), and simplify the logic by removing unnecessary window functions and row numbering. The queries now use new common table expressions (CTEs) to more directly identify current records for singles and averages at each region level.

**Query Logic Improvements:**

* Replaced the use of `ordered_wrs`/`ordered_records` and row numbering with new `current_single` and `current_average` CTEs that select only the current record for each event and region, ensuring only standing records are included. [[1]](diffhunk://#diff-4913101dedf799b61e0a95ad262596f44e74afd010751d5f463030cd9836b27aL15-R55) [[2]](diffhunk://#diff-4913101dedf799b61e0a95ad262596f44e74afd010751d5f463030cd9836b27aL97-L156) [[3]](diffhunk://#diff-4913101dedf799b61e0a95ad262596f44e74afd010751d5f463030cd9836b27aL190-L243)

* Simplified the combination of single and average records into a single `combined_r` CTE, removing redundant logic and making the queries more readable and maintainable. [[1]](diffhunk://#diff-4913101dedf799b61e0a95ad262596f44e74afd010751d5f463030cd9836b27aL24-L64) [[2]](diffhunk://#diff-4913101dedf799b61e0a95ad262596f44e74afd010751d5f463030cd9836b27aL97-L156) [[3]](diffhunk://#diff-4913101dedf799b61e0a95ad262596f44e74afd010751d5f463030cd9836b27aL190-L243)

**Data Accuracy and Filtering:**

* Enhanced the filtering logic to ensure that only records that are currently standing (i.e., not superseded by better results) are selected, using `not exists` subqueries to exclude superseded records. [[1]](diffhunk://#diff-4913101dedf799b61e0a95ad262596f44e74afd010751d5f463030cd9836b27aL15-R55) [[2]](diffhunk://#diff-4913101dedf799b61e0a95ad262596f44e74afd010751d5f463030cd9836b27aL97-L156) [[3]](diffhunk://#diff-4913101dedf799b61e0a95ad262596f44e74afd010751d5f463030cd9836b27aL190-L243)

* Improved region identification by joining with `countries` and `continents` tables to accurately assign records to their respective regions or countries. [[1]](diffhunk://#diff-4913101dedf799b61e0a95ad262596f44e74afd010751d5f463030cd9836b27aL97-L156) [[2]](diffhunk://#diff-4913101dedf799b61e0a95ad262596f44e74afd010751d5f463030cd9836b27aL190-L243)

**Output and Sorting Adjustments:**

* Updated the final result set to order by `event_id` and `record_type` instead of `e.rank`, and applied consistent naming and formatting for output columns. [[1]](diffhunk://#diff-4913101dedf799b61e0a95ad262596f44e74afd010751d5f463030cd9836b27aL74-R97) [[2]](diffhunk://#diff-4913101dedf799b61e0a95ad262596f44e74afd010751d5f463030cd9836b27aL167-R210) [[3]](diffhunk://#diff-4913101dedf799b61e0a95ad262596f44e74afd010751d5f463030cd9836b27aL254-R317)

* Changed references in the final selection from previous CTEs (e.g., `current_records`, `current_wrs`) to the new `combined_r` CTE, reflecting the new query structure. [[1]](diffhunk://#diff-4913101dedf799b61e0a95ad262596f44e74afd010751d5f463030cd9836b27aL74-R97) [[2]](diffhunk://#diff-4913101dedf799b61e0a95ad262596f44e74afd010751d5f463030cd9836b27aL167-R210) [[3]](diffhunk://#diff-4913101dedf799b61e0a95ad262596f44e74afd010751d5f463030cd9836b27aL254-R317)